### PR TITLE
Remove update-notifier

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,17 +1,10 @@
 'use strict';
 var net = require('net');
 var chalk = require("chalk");
-const pkg = require("./package.json");
-const updateNotifier = require('update-notifier');
 const queue = require("queue");
 
 var sendQueue = queue({autostart:true, concurrency:1})
 
-
-// Checks for available update and returns an instance
-const notifier = updateNotifier({pkg}) // Notify using the built-in convenience method
-notifier.notify();	
-			
 
 var exports = module.exports;
 var globals = [];																																	


### PR DESCRIPTION
In version 1.5 of homebridge getting the following error:

[7/27/2022, 10:24:19 AM] ====================
[7/27/2022, 10:24:19 AM] ERROR LOADING PLUGIN homebridge-neosmartshades:
[7/27/2022, 10:24:19 AM] Error [ERR_REQUIRE_ESM]: require() of ES Module /homebridge/node_modules/homebridge-neosmartshades/node_modules/update-notifier/index.js from /homebridge/node_modules/homebridge-neosmartshades/index.js not supported.
Instead change the require of /homebridge/node_modules/homebridge-neosmartshades/node_modules/update-notifier/index.js in /homebridge/node_modules/homebridge-neosmartshades/index.js to a dynamic import() which is available in all CommonJS modules.
    at Object.<anonymous> (/homebridge/node_modules/homebridge-neosmartshades/index.js:4:24)
    at Plugin.load (/homebridge/node_modules/homebridge/lib/plugin.js:164:108)
    at PluginManager.initializeInstalledPlugins (/homebridge/node_modules/homebridge/lib/pluginManager.js:66:30)
    at async Server.start (/homebridge/node_modules/homebridge/lib/server.js:125:9)
[7/27/2022, 10:24:19 AM] ====================


Proposing that we remove the notifier so that it can run in version 1.5 of homebridge.  